### PR TITLE
WIP: adding the docker container for an openldap server

### DIFF
--- a/compose/.env_openldap
+++ b/compose/.env_openldap
@@ -1,0 +1,11 @@
+# This file is setting up a composed Galaxy instance with support
+# for authentication through ldap.
+# Docker compose will use parameters specified in an `.env` file
+# next to the docker-compose.yml file.
+# We recommend to symlink this file and play around with different
+# Galaxy deployments.
+# ln -sf .env_openldap .env
+
+
+# default destination is our SLURM cluster
+GALAXY_CONFIG_AUTH_CONFIG_FILE: config/auth_conf_openldap.xml

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -306,5 +306,23 @@ services:
     labels:
         kompose.service.type: nodeport
 
+  # OpenLDAP server
+  ldap:
+    image: jelle/galaxy-openldap
+    container_name: openldap
+    ports:
+        - "389:389"
+        - "636:636"
+    networks:
+        - galaxy
+    volumes:
+        - ${EXPORT_DIR:-/export}/:/export
+    restart: unless-stopped
+    deploy:
+      placement:
+        constraints: [node.role == manager]
+    labels:
+        kompose.service.type: nodeport
+
 networks:
     galaxy:

--- a/compose/galaxy-openldap/config/auth_conf_openldap.xml
+++ b/compose/galaxy-openldap/config/auth_conf_openldap.xml
@@ -1,0 +1,25 @@
+<authenticator>
+  <!-- authentication settings for openldap with auto group generation -->
+  <type>ldap</type>
+  <options>
+    (..)
+    <server>ldap://openldap</server>
+    <ldap-options>OPT_X_TLS_REQUIRE_CERT=OPT_X_TLS_NEVER</ldap-options>
+    <login-use-username>True</login-use-username>
+    <continue-on-failure>False</continue-on-failure>
+    <search-base>dc=example,dc=org</search-base>
+    <search-fields>uid,mail</search-fields>
+    <search-filter>(mail={email})</search-filter>
+    <search-filter>(uid={username})</search-filter>
+    <bind-user>{dn}</bind-user>
+    <bind-password>{password}</bind-password>
+    <auto-register-username>{uid}</auto-register-username>
+    <auto-register-email>{mail}</auto-register-email>
+    <search-user>cn=admin,dc=example,dc=org</search-user>
+    <search-password>admin</search-password>
+    <auto-create-roles>True</auto-create-roles>
+    <auto-create-groups>True</auto-create-groups>
+    <auto-assign-roles-to-groups-only>True</auto-assign-roles-to-groups-only>
+    <auto-register-roles>gidNumber</auto-register-roles>
+  </options>
+</authenticator>


### PR DESCRIPTION
XREF: https://github.com/scholtalbers/docker-galaxy-openldap/issues/1

I started this branch a while ago but couldn't actually get the `./buildlocal.sh` working at the time, so this is the state I left it at (did do a rebase).
What is needed is to actually get the `auth_conf.xml` in place, make sure the galaxy instance can connect and make a nicer/more comprehensive [galaxy.ldif](https://github.com/scholtalbers/docker-galaxy-openldap/blob/master/bootstrap/ldif/galaxy.ldif) for the ldap server initialization.

I might work on this, but also happy if anyone takes over ;) - and happy for any (obvious) pointers on how to make this work.