### PR TITLE
Fix galaxy-server/Dockerfile to be supported on RHEL8 with podman

### DIFF
--- a/compose/galaxy-server/Dockerfile
+++ b/compose/galaxy-server/Dockerfile
@@ -57,13 +57,14 @@ COPY ./files/common_cleanup.sh /usr/bin/common_cleanup.sh
 # Install Galaxy
 RUN apt update && apt install --no-install-recommends libcurl4-openssl-dev libssl-dev python3-dev python3-pip -y \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3 9 \
+    && pip3 install drmaa psycopg2 pycurl pykube \
+    && pip3 install importlib-metadata importlib-resources pathlib2 ruamel.yaml.clib typing zipp \
+    && pip3 install attmap==0.12.11 rdflib-jsonld==0.4.0 refgenconf==0.7.0 yacman==0.6.7 \
     && mkdir "${GALAXY_ROOT}" \
     && curl -L -s $GALAXY_REPO/archive/$GALAXY_RELEASE.tar.gz | tar xzf - --strip-components=1 -C $GALAXY_ROOT \
     && cd $GALAXY_ROOT \
     && ./scripts/common_startup.sh \
     && . $GALAXY_ROOT/.venv/bin/activate \
-    && pip3 install drmaa psycopg2 pycurl pykube \
-    && pip3 install importlib-metadata importlib-resources pathlib2 ruamel.yaml.clib typing zipp \
     && deactivate \
     && rm -rf .ci .circleci .coveragerc .gitignore .travis.yml CITATION CODE_OF_CONDUCT.md CONTRIBUTING.md CONTRIBUTORS.md \
               LICENSE.txt Makefile README.rst SECURITY_POLICY.md pytest.ini tox.ini \

--- a/compose/galaxy-server/Dockerfile
+++ b/compose/galaxy-server/Dockerfile
@@ -116,6 +116,7 @@ RUN apt update && apt install --no-install-recommends curl gcc gnupg2 libgomp1 l
     # Cython and wheel are needed to later install pysam..
     && pip3 install Cython wheel \
     && pip3 install pysam \
+    && pip3 install attmap==0.12.11 \
     && /usr/bin/common_cleanup.sh
 
 # GALAXY_USER should be able to run docker without root permissions


### PR DESCRIPTION
I realized on RHEL8 or CENTOS 8, some python packages can't be installed with **use_2to3** removed from python3-setuptools>v58.

What's funny, it seems the Dockerfile use python3-setuptools version 53?!?!?!?!?!?!

I added extra **pip3** to install missed packages.